### PR TITLE
Don't auto-post by default

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -82,7 +82,7 @@ fn main() {
     let current_user = discord.get_current_user()
         .expect("Failed to get current user");
 
-    let mut auto_post_enabled = true;
+    let mut auto_post_enabled = false;
     let mut freq = 1;
     let mut channel_id = ChannelId(
         env::var("DISCORD_CHANNEL_ID")


### PR DESCRIPTION
This is really not a great default. With auto-post enabled by default, it is impossible to guarantee clean operation when starting, as the bot cannot be cleanly started and moved into the appropriate channel without possibly printing stuff in the wrong channel.